### PR TITLE
Implement first run script to configure the databases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,27 +13,27 @@ help:
 
 # Build Opal Docker image
 build:
-	sudo docker build --no-cache=$(no_cache) -t="obiba/opal:snapshot" .
+	docker build --no-cache=$(no_cache) -t="obiba/opal:snapshot" .
 
 # Run a Opal Docker instance
 run:
-	sudo docker run -d -p 8843:8443 -p 8880:8080 --name opal --link mongodb:mongodb obiba/opal:snapshot
+	docker run -d -p 8843:8443 -p 8880:8080 --name opal --link mongodb:mongodb obiba/opal:snapshot
 
 # Run a Opal Docker instance with shell
 run-sh:
-	sudo docker run -ti -p 8843:8443 -p 8880:8080 --name opal --link mongodb:mongodb obiba/opal:snapshot bash
+	docker run -ti -p 8843:8443 -p 8880:8080 --name opal --link mongodb:mongodb obiba/opal:snapshot bash
 
 # Show logs
 logs:
-	sudo docker logs opal
+	docker logs opal
 
 # Stop a Opal Docker instance
 stop:
-	sudo docker stop opal
+	docker stop opal
 
 # Stop and remove a Opal Docker instance
 clean: stop
-	sudo docker rm opal
+	docker rm opal
 
 #
 # MongoDB
@@ -41,12 +41,12 @@ clean: stop
 
 # Run a Mongodb Docker instance
 run-mongodb:
-	sudo docker run -d --name mongodb dockerfile/mongodb
+	docker run -d --name mongodb dockerfile/mongodb
 
 # Stop a Mongodb Docker instance
 stop-mongodb:
-	sudo docker stop mongodb
+	docker stop mongodb
 
 # Stop and remove a Mongodb Docker instance
 clean-mongodb: stop-mongodb
-	sudo docker rm mongodb
+	docker rm mongodb

--- a/bin/first_run.sh
+++ b/bin/first_run.sh
@@ -1,0 +1,13 @@
+# Configure some databases for IDs and data
+echo "Initializing Opal databases..."
+while [ `opal rest -o https://localhost:8443 -u administrator -p password -m GET /system/databases | grep -ch "mongodb"` -eq 0 ]
+do
+    echo -n "."
+    sleep 5
+    sed s/@mongo_host@/$MONGODB_PORT_27017_TCP_ADDR/g /opt/opal/data/idsdb.json | \
+        sed s/@mongo_port@/$MONGODB_PORT_27017_TCP_PORT/g | \
+        opal rest -o https://localhost:8443 -u administrator -p password -m POST /system/databases --content-type "application/json"
+    sed s/@mongo_host@/$MONGODB_PORT_27017_TCP_ADDR/g /opt/opal/data/mongodb.json | \
+        sed s/@mongo_port@/$MONGODB_PORT_27017_TCP_PORT/g | \
+        opal rest -o https://localhost:8443 -u administrator -p password -m POST /system/databases --content-type "application/json"
+done

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -4,19 +4,14 @@ service opal start
 # Wait for the opal server to be up and running
 sleep 5
 
-# Configure some databases for IDs and data
-echo "Initializing Opal databases..."
-while [ `opal rest -o https://localhost:8443 -u administrator -p password -m GET /system/databases | grep -ch "mongodb"` -eq 0 ]
-do
-	echo -n "."
-	sleep 5
-	sed s/@mongo_host@/$MONGODB_PORT_27017_TCP_ADDR/g /opt/opal/data/idsdb.json | \
-		sed s/@mongo_port@/$MONGODB_PORT_27017_TCP_PORT/g | \
-  		opal rest -o https://localhost:8443 -u administrator -p password -m POST /system/databases --content-type "application/json"
-	sed s/@mongo_host@/$MONGODB_PORT_27017_TCP_ADDR/g /opt/opal/data/mongodb.json | \
-  		sed s/@mongo_port@/$MONGODB_PORT_27017_TCP_PORT/g | \
-  		opal rest -o https://localhost:8443 -u administrator -p password -m POST /system/databases --content-type "application/json"
-done
+# check if 1st run. Then configure database.
+if [ -e /opt/opal/bin/first_run.sh ]
+    then
+    bash /opt/opal/bin/first_run.sh
+    mv /opt/opal/bin/first_run.sh /opt/opal/bin/first_run.sh.done
+fi
+
+
 echo "."
 
 # Tail the log


### PR DESCRIPTION
Opal container seems stuck in while loop when restarting after a docker stop/kill. This fixes it for me.
Also `sudo` is not needed if current user is a member of `docker` group.